### PR TITLE
Could org.apache.atlas:impala-hook-api:3.0.0-SNAPSHOT drop off redundant dependencies? 

### DIFF
--- a/bdp-govern/metadata/atlas/addons/impala-hook-api/pom.xml
+++ b/bdp-govern/metadata/atlas/addons/impala-hook-api/pom.xml
@@ -30,4 +30,27 @@
   <name>Apache Atlas Impala Hook API</name>
   <packaging>jar</packaging>
 
+  <dependencies>
+    <dependency>
+      <groupId>cglib</groupId>
+      <artifactId>cglib</artifactId>
+      <version>2.2.2</version>
+      <type>jar</type>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <version>1.7.30</version>
+      <type>jar</type>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jul-to-slf4j</artifactId>
+      <version>1.7.30</version>
+      <type>jar</type>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
 </project>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/78527112/166089884-fe3a9ef5-c0a1-41e1-9e6f-389e9c2f3981.png)

This figure presents the dependency tree between multiple modules in **_org.apache.atlas:apache-atlas:3.0.0-SNAPSHOT_**. As shown in this figure, Library 
##
org.slf4j:slf4j-log4j12:jar:1.7.30:compile
org.slf4j:jul-to-slf4j:jar:1.7.30:compile
cglib:cglib:jar:2.2.2:compile
asm:asm:jar:3.3.1:compile

---
in **_<module>build-tools</module>
        <module>test-tools</module>
        <module>intg</module>
        <module>common</module>
        <module>server-api</module>
        <module>notification</module>
        <module>client</module>
        <module>graphdb</module>
        <module>repository</module>
        <module>authorization</module>
        <module>dashboardv2</module>
        <module>dashboardv3</module>
        <module>webapp</module>
        <module>docs</module>
        <module>addons/hdfs-model</module>
        <module>plugin-classloader</module>
        <module>addons/hive-bridge-shim</module>
        <module>addons/hive-bridge</module>
        <module>addons/falcon-bridge-shim</module>
        <module>addons/falcon-bridge</module>
        <module>addons/sqoop-bridge-shim</module>
        <module>addons/sqoop-bridge</module>
        <module>addons/storm-bridge-shim</module>
        <module>addons/storm-bridge</module>
        <module>addons/hbase-bridge-shim</module>
        <module>addons/hbase-bridge</module>
        <module>addons/hbase-testing-util</module>
        <module>addons/kafka-bridge</module>
        <module>tools/classification-updater</module>
        <module>tools/atlas-index-repair</module>
        <module>addons/impala-hook-api</module>
        <module>addons/impala-bridge-shim</module>
        <module>addons/impala-bridge</module>
        <module>distro</module>
        <module>atlas-examples</module>_**

are inherited from their parent module. However, it is not used by **_addons/impala-hook-api_**. We can perform refactoring operations in the pom, by removing such redundant dependencies in **_addons/impala-hook-api_**.

Specifically, the scope of **_cglib:cglib:2.2.2, org.slf4j:slf4j-log4j12:1.7.30, org.slf4j:jul-to-slf4j:1.7.30_** in **_addons/impala-hook-api_** can be changed from compile to provided. The revisions in the pom are described as follows:
